### PR TITLE
Jj update prepare validation and cl3d

### DIFF
--- a/reliontomo/protocols/protocol_3d_classify_subtomograms.py
+++ b/reliontomo/protocols/protocol_3d_classify_subtomograms.py
@@ -145,7 +145,7 @@ class ProtRelion3DClassifySubtomograms(ProtRelionRefineSubtomograms):
                       label='Use GPU acceleration?',
                       help='If set to Yes, it will use available gpu resources for some calculations.')
         form.addParam('gpusToUse', StringParam,
-                      condition='doGpu',
+                      condition='doImageAlignment and doGpu',
                       default='0',
                       label='GPUs to use:',
                       help='It can be used to provide a list of which GPUs (e. g. "0:1:2:3") to use. MPI-processes are '
@@ -248,7 +248,7 @@ class ProtRelion3DClassifySubtomograms(ProtRelionRefineSubtomograms):
             cmd += '--skip_align '
 
         # Compute args
-        cmd += self._genComputeBaseCmd()
+        cmd += self._genComputeBaseCmd(onlyCl3d=not self.doImageAlignment.get())
         cmd += '--pad %i ' % (1 if self.skipPadding.get() else 2)
 
         # Additional args

--- a/reliontomo/protocols/protocol_base_refine.py
+++ b/reliontomo/protocols/protocol_base_refine.py
@@ -306,7 +306,7 @@ class ProtRelionRefineBase(ProtRelionTomoBase):
         cmd += '--particle_diameter %i ' % self.maskDiameter.get()
         return cmd
 
-    def _genComputeBaseCmd(self):
+    def _genComputeBaseCmd(self, onlyCl3d=False):
         cmd = ''
         if not self.parallelDiscIO.get():
             cmd += '--no_parallel_disc_io '
@@ -319,7 +319,7 @@ class ProtRelionRefineBase(ProtRelionTomoBase):
             cmd += '--dont_combine_weights_via_disc '
         if self.scratchDir.get():
             cmd += '--scratch_dir %s ' % self.scratchDir.get()
-        if self.doGpu.get():
+        if self.doGpu.get() and not onlyCl3d:
             cmd += '--gpu "%s" ' % self.gpusToUse.get()
         return cmd
 

--- a/reliontomo/protocols/protocol_prepare_data.py
+++ b/reliontomo/protocols/protocol_prepare_data.py
@@ -166,9 +166,9 @@ class ProtRelionPrepareData(EMProtocol):
                                               isRelion=True)
         # Thickness of the tomogram
         tomoSizeDict = {}
-        tomoSet = self.coords.getPrecedents()
+        tomoList = [tomo.clone() for tomo in self.coords.getPrecedents()]
         coordScale = self.coordScale.get()
-        for tomo in tomoSet:
+        for tomo in tomoList:
             x, y, thickness = tomo.getDim()
             tomoSizeDict[tomo.getTsId()] = {X_SIZE: x * coordScale,
                                             Y_SIZE: y * coordScale,

--- a/reliontomo/protocols/protocol_prepare_data.py
+++ b/reliontomo/protocols/protocol_prepare_data.py
@@ -41,6 +41,10 @@ from tomo.utils import getNonInterpolatedTsFromRelations
 
 # Other constants
 DEFOCUS = 'defocus'
+THICKNESS = 'thickness'
+X_SIZE = 'x'
+Y_SIZE = 'y'
+DIMS = 'dims'
 
 
 class outputObjects(Enum):
@@ -161,15 +165,19 @@ class ProtRelionPrepareData(EMProtocol):
                                               join(defocusPath, ctfTomo.getTsId() + '.' + DEFOCUS),
                                               isRelion=True)
         # Thickness of the tomogram
-        x, y, thickness = self.coords.getPrecedents().getDim()
-        # Dimensions at TS sampling rate
-        x = x * self.coordScale.get()
-        y = y * self.coordScale.get()
-        thickness = thickness * self.coordScale.get()
+        tomoSizeDict = {}
+        tomoSet = self.coords.getPrecedents()
+        coordScale = self.coordScale.get()
+        for tomo in tomoSet:
+            x, y, thickness = tomo.getDim()
+            tomoSizeDict[tomo.getTsId()] = {X_SIZE: x * coordScale,
+                                            Y_SIZE: y * coordScale,
+                                            THICKNESS: thickness * coordScale}
 
         # Simulate the etomo files that serve as entry point to relion4
-        self._simulateETomoFiles(self.tsSet, thickness=thickness, binned=1, dims=(x, y),
-                                 binByFactor=self.coordScale, whiteList=self.coordsVolIds, swapDims=self.swapXY.get())
+        self._simulateETomoFiles(self.tsSet, tomoSizeDict, binned=1, binByFactor=self.coordScale,
+                                 whiteList=self.coordsVolIds, swapDims=self.swapXY.get())
+
         # Write the tomograms star file
         writeSetOfTomograms(self.tsSet,
                             self._getStarFilename(IN_TOMOS_STAR),
@@ -254,12 +262,16 @@ class ProtRelionPrepareData(EMProtocol):
     def _decodeHandeness(self):
         return -1 if self.handeness.get() else 1
 
-    def _simulateETomoFiles(self, imgSet, whiteList=None, **kwargs):
+    def _simulateETomoFiles(self, imgSet, tomoSizeDict, whiteList=None, **kwargs):
         """Simulate the etomo files that serve as entry point to relion4
         """
         for ts in imgSet:
             tsId = ts.getTsId()
-            if whiteList is None or tsId in whiteList:
+            # Get the size of the corresponding tomogram, as it may differ from one to another
+            tomoIdMatchDict = tomoSizeDict.get(tsId, None)
+            if tomoIdMatchDict and (whiteList is None or tsId in whiteList):
+                kwargs[THICKNESS] = tomoIdMatchDict[THICKNESS]
+                kwargs[DIMS] = (tomoIdMatchDict[X_SIZE], tomoIdMatchDict[Y_SIZE])
                 # creating a folder where all data will be generate
                 folderName = self._getTmpPath(tsId)
                 makePath(folderName)

--- a/reliontomo/tests/test_import_star_files.py
+++ b/reliontomo/tests/test_import_star_files.py
@@ -75,7 +75,7 @@ class TestImportFromStarFile(BaseTest):
                                            inputSetOfTomograms=cls.inTomoSet,
                                            binning=2)
         cls.launchProtocol(protNormTomogram)
-        outputTomos = getattr(protNormTomogram, 'outputSetOfTomograms', None)
+        outputTomos = protNormTomogram.Tomograms
         cls.assertIsNotNone(outputTomos, 'No tomograms were genetated.')
         return outputTomos
 

--- a/reliontomo/tests/test_refine_cycle.py
+++ b/reliontomo/tests/test_refine_cycle.py
@@ -62,7 +62,7 @@ OUTPUT_COORDS = importStarOutputs.coordinates.name
 OUTPUT_CLASSES = cl3dOutputs.classes.name
 
 
-class TestRefinceCycle(BaseTest):
+class TestRefineCycle(BaseTest):
     fscMaskBin2 = None
     normTS = None
     alignedTS = None


### PR DESCRIPTION
- Fix the tomogram star generation in the protocol "prepare data" to read the dims of the tomograms one by one as they may vary.
- Fix the tests for importing from star file
- Fix cl3d without alignment gpu error after having copied a cl3d protocol executed with cl3d and alignment and execute now unchecking the alignment option in the form.