### PR TITLE
adjustments on the entry to relion-4

### DIFF
--- a/reliontomo/protocols/protocol_prepare_data.py
+++ b/reliontomo/protocols/protocol_prepare_data.py
@@ -97,33 +97,38 @@ class ProtRelionPrepareData(EMProtocol, ProtTomoBase):
                       pointerClass='SetOfTiltSeries',
                       label="Input tilt series",
                       important=True,
-                      expertLevel=LEVEL_ADVANCED,
                       allowsNull=True)
 
         form.addParam('flipZCoords', BooleanParam,
                       label='Flip Z coordinate?',
                       default=False,
+                      help='This option is generally False if your coordinates are displayed correctly in Scipion. '
+                           'You may want to check this to True only if you see that the extracted subtomograms'
+                           ' are wrong.',
                       expertLevel=LEVEL_ADVANCED
                       )
 
         form.addParam('flipYZ', BooleanParam,
                       label='Has tomogram been flipped along Y and Z?',
-                      default=False,
-                      help='If the tomogram has been flipped along Y and Z (i.e. rotated around X) '
-                           'after the reconstruction and before the particles have been picked, this '
-                           'will apply the same transformation to the relion coordinate system. This will '
-                           'allow relion to use particle positions defined in the X-rotated tomogram unchanged.')
+                      default=True,
+                      help='This option is generally True if the slices of your tomogram are displayed on slice Z in '
+                           'Imod. '
+                           'Usually, a tomogram is flipped along Y and Z (i.e. rotated around X with 90 degrees) '
+                           'after the reconstruction and before the particles have been picked. This '
+                           'will tell Relion to apply the same transformation to the coordinate system.')
         form.addParam('flipZ', BooleanParam,
                       label='Has the Z axis been flipped?',
-                      default=False,
-                      help='Same as above, in case the Z axis has been flipped. This can be used together with '
-                           'the flipYZ option.')
+                      default=True,
+                      help='This option is generally True when you apply reconstrucion in Imod. This is usually used '
+                           'together with the flipYZ option.')
 
         form.addParam('swapXY', BooleanParam,
                       label='Swap X with Y dimensions of the tilt series',
-                      default=True,
+                      default=False,
+                      expertLevel=LEVEL_ADVANCED,
                       help='This may be a trial and error parameter. Depending of the reconstruction path of '
-                           'your tomograms we you may need to deactivate this option to get good results.')
+                           'your tomograms we you may need to deactivate this option to get good results. '
+                           'This option will be deprecated in the future')
 
     # -------------------------- INSERT steps functions -----------------------
     def _insertAllSteps(self):


### PR DESCRIPTION
Hello
After experimenting with Relion in and out of scipion, I propose adjusting the prepare data protocol to the following:
1- Keep the import tilt series shown rather than hidden: One reason is that CTF might be estimated on a binned tilt series, and another reason is that Relion expects a normalized tilt series which should not be done before CTF. It allowsNull, so if not provided will be taken from the relations.
2- FlipYZ is generally true and not false. Even in Relion interface, FlipYZ is true. This should be generally true since the beam axis is along Y but everyone wants to show the tomogram over Z in Imod. This should be set to true in order to be coherent with the default parameter in Aretomo https://github.com/scipion-em/scipion-em-aretomo/blob/master/aretomo/protocols/protocol_aretomo.py#L186 and Imod automatic reconstruction protocol of tilt series https://github.com/scipion-em/scipion-em-imod/blob/devel/imod/protocols/protocol_tomoReconstruction.py
3- I tried different variations of picking outside of scipion and importing, or picking inside scipion, and never needed to swapXY. If you really think this option is useful, keep it, but at least set it to False and let it be advanced.
Cheers
Mohamad