### PR TITLE
v4.0.2:

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+v4.0.2:
+  Users:
+    - RelionSubtomograms do not longer have an index in the path. Just the file name. This allows for correct visualization
+      of the subtomograms in the metadata viewers.
 v4.0.1:
   Users:
     - Ensure that the pseudo-subtomograms of the initial model protocol have even dimensions.

--- a/reliontomo/convert/convert50_tomo.py
+++ b/reliontomo/convert/convert50_tomo.py
@@ -999,7 +999,7 @@ class Reader(ReaderTomo):
             # Set the transformation matrix
             t.setMatrix(getTransformMatrixFromRow(row, sRate=sRate, isRe5Star=True))
             psubtomo.setTransform(t)
-            psubtomo.setIndex(counter)
+            # This is not necessary: psubtomo.setIndex(counter)
             psubtomo.setClassId(row.get(RLN_CLASSNUMBER, 1))
 
             # Add current pseudosubtomogram to the output set


### PR DESCRIPTION
  Users:
    - RelionSubtomograms do not longer have an index in the path. Just the file name. This allows for correct visualization of the subtomograms in the metadata viewers.