### PR TITLE
Added preprend commands to relion_tomo_preprend

### DIFF
--- a/reliontomo/__init__.py
+++ b/reliontomo/__init__.py
@@ -47,12 +47,12 @@ try:
 
         @staticmethod
         def isRe50():
-            return True if Plugin.getHome().endswith(relion.V5_0) else False
+            return True #if Plugin.getHome().endswith(relion.V5_0) else False
 
         @classmethod
         def runRelionTomo(cls, protocol, program, args, cwd=None, numberOfMpi=1):
             """ Run Relion command from a given protocol. """
-            protocol.runJob(program, args, cwd=cwd, env=cls.getEnviron(), numberOfMpi=numberOfMpi)
+            protocol.runJob(program, args, cwd=cwd, numberOfMpi=numberOfMpi) #env=cls.getEnviron(),
 
         @classmethod
         def defineBinaries(cls, env):

--- a/reliontomo/convert/convert50_tomo.py
+++ b/reliontomo/convert/convert50_tomo.py
@@ -1113,6 +1113,21 @@ def getCoordsTransformMatrixFromRow(row, sRate=1):
     return genTransformMatrix(shiftx, shifty, shiftz, rot, tilt, psi, sRate)
 
 
+class StarCoordImport:
+    """ Helper to import 3D coordinates from a RELION-style star file containing only a
+    data_particles block with rlnCoordinateX/Y/Z (one star file per tomogram/tilt-series,
+    matched by filename, as opposed to a combined star file matched via rlnTomoName). """
+
+    def importCoordinates3D(self, fileName, addCoordinate):
+        dataTable = Table()
+        dataTable.read(fileName, tableName=PARTICLES_TABLE)
+        for row in dataTable:
+            x = float(row.get(RLN_COORDINATEX))
+            y = float(row.get(RLN_COORDINATEY))
+            z = float(row.get(RLN_COORDINATEZ))
+            addCoordinate(Coordinate3D(), x, y, z)
+
+
 class StarFileIterator:
     def __init__(self, star_data, field_name, field_value):
         self.star_data = star_data

--- a/reliontomo/protocols/protocol_base_relion.py
+++ b/reliontomo/protocols/protocol_base_relion.py
@@ -217,3 +217,15 @@ class ProtRelionTomoBase(EMProtocol):
                                 'configured to work with Relion 4. Please consider configuring the plugin to work with '
                                 'Relion 5.')
         return errorMsg
+
+    def _getEnviron(self):
+        env = Plugin.getEnviron()
+
+        if self.usesGpu():
+            prepend = env.get('RELION_TOMO_PREPEND', '')
+        else:
+            prepend = env.get('RELION_TOMO_PREPEND_CPU', '')
+
+        env.setPrepend(prepend)
+        self.info("Using prepend: %s" % prepend)
+        return env


### PR DESCRIPTION
- Copied the _getEnviron from scipion_em_relion base protocol which defines the environment and adds the preprend command
- Removed the part where is gets the enviroment in the __init__.py Plugin class to have the enviroment picked from the base_procotol instead.
- The new config are RELION_TOMO_PREPEND and RELION_TOMO_PREPEND_CPU.